### PR TITLE
R3-101 | Corrected the webdate field to clear when right clicked.

### DIFF
--- a/src/main/java/parker/serb/REP/REPElectionPanel.form
+++ b/src/main/java/parker/serb/REP/REPElectionPanel.form
@@ -440,7 +440,7 @@
                               </Group>
                               <EmptySpace max="-2" attributes="0"/>
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="ballotOneTextBox" pref="264" max="32767" attributes="0"/>
+                                  <Component id="ballotOneTextBox" pref="263" max="32767" attributes="0"/>
                                   <Component id="ballotTwoTextBox" max="32767" attributes="0"/>
                                   <Component id="ballotThreeTextBox" alignment="0" max="32767" attributes="0"/>
                                   <Component id="ballotFourTextBox" alignment="0" max="32767" attributes="0"/>
@@ -901,7 +901,7 @@
                                       <Component id="amPMComboBox" min="-2" pref="64" max="-2" attributes="0"/>
                                   </Group>
                                   <Component id="ballotsCountDate" alignment="0" max="32767" attributes="0"/>
-                                  <Component id="ballotsCountDay" alignment="0" pref="300" max="32767" attributes="0"/>
+                                  <Component id="ballotsCountDay" alignment="0" pref="278" max="32767" attributes="0"/>
                                   <Component id="pollingEndDate" alignment="0" max="32767" attributes="0"/>
                                   <Component id="pollingStartDate" alignment="0" max="32767" attributes="0"/>
                               </Group>

--- a/src/main/java/parker/serb/REP/REPElectionPanel.java
+++ b/src/main/java/parker/serb/REP/REPElectionPanel.java
@@ -2440,7 +2440,7 @@ public class REPElectionPanel extends javax.swing.JPanel {
     }//GEN-LAST:event_ballotsCountDateMouseClicked
 
     private void eligibilityListDateMouseClicked(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_eligibilityListDateMouseClicked
-        clearDate(eligibiltyDateTextBox, evt);
+        clearDate(eligibilityListDate, evt);
     }//GEN-LAST:event_eligibilityListDateMouseClicked
 
     private void multiCaseElectionCheckBoxStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_multiCaseElectionCheckBoxStateChanged


### PR DESCRIPTION
Closes #670  

There was three date boxes for that panel and the one that was getting removed was the incorrect one, but was on a different type of election so it was not noticeable with the way the panels are configured since it was a different election type.

eligibilityDate
eligibilityListDate
eligibiltyDateTextBox